### PR TITLE
Update AccountInformationAccessRequestService

### DIFF
--- a/src/main/java/com/ibanity/apis/client/products/xs2a/models/AccountInformationAccessRequest.java
+++ b/src/main/java/com/ibanity/apis/client/products/xs2a/models/AccountInformationAccessRequest.java
@@ -21,11 +21,7 @@ public class AccountInformationAccessRequest implements IbanityModel {
     private UUID id;
     private String selfLink;
 
-    private String consentReference;
-    private String redirectUri;
     private String status;
-    private String locale;
-    private String customerIpAddress;
     private boolean allowFinancialInstitutionRedirectUri;
 
     @Builder.Default

--- a/src/main/java/com/ibanity/apis/client/products/xs2a/models/create/AccountInformationAccessRequestCreationQuery.java
+++ b/src/main/java/com/ibanity/apis/client/products/xs2a/models/create/AccountInformationAccessRequestCreationQuery.java
@@ -27,6 +27,7 @@ public final class AccountInformationAccessRequestCreationQuery {
     private String locale;
     private String customerIpAddress;
     private boolean allowFinancialInstitutionRedirectUri;
+    private boolean skipIbanityCompletionCallback;
 
     private IbanityPagingSpec pagingSpec;
 

--- a/src/main/java/com/ibanity/apis/client/products/xs2a/models/read/AccountInformationAccessRequestReadQuery.java
+++ b/src/main/java/com/ibanity/apis/client/products/xs2a/models/read/AccountInformationAccessRequestReadQuery.java
@@ -1,0 +1,25 @@
+package com.ibanity.apis.client.products.xs2a.models.read;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Collections.emptyMap;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+public final class AccountInformationAccessRequestReadQuery {
+
+    private String customerAccessToken;
+    private UUID accountInformationAccessRequestId;
+    private UUID financialInstitutionId;
+
+    @Builder.Default
+    private Map<String, String> additionalHeaders = emptyMap();
+}

--- a/src/main/java/com/ibanity/apis/client/products/xs2a/services/AccountInformationAccessRequestsService.java
+++ b/src/main/java/com/ibanity/apis/client/products/xs2a/services/AccountInformationAccessRequestsService.java
@@ -2,13 +2,23 @@ package com.ibanity.apis.client.products.xs2a.services;
 
 import com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest;
 import com.ibanity.apis.client.products.xs2a.models.create.AccountInformationAccessRequestCreationQuery;
+import com.ibanity.apis.client.products.xs2a.models.read.AccountInformationAccessRequestReadQuery;
 
 public interface AccountInformationAccessRequestsService {
 
     AccountInformationAccessRequest create(
             AccountInformationAccessRequestCreationQuery accountInformationAccessRequestCreationQuery);
 
+    /**
+     * This method uses an ambiguous parameter.
+     *
+     * @deprecated use {@link #find(AccountInformationAccessRequestReadQuery)} instead.
+     */
+    @Deprecated
     AccountInformationAccessRequest find(
             AccountInformationAccessRequestCreationQuery accountInformationAccessRequestCreationQuery);
+
+    AccountInformationAccessRequest find(
+            AccountInformationAccessRequestReadQuery accountInformationAccessRequestReadQuery);
 
 }

--- a/src/main/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImpl.java
+++ b/src/main/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImpl.java
@@ -13,6 +13,7 @@ import com.ibanity.apis.client.products.xs2a.models.create.AccountInformationAcc
 import com.ibanity.apis.client.products.xs2a.models.create.AuthorizationPortalCreationQuery;
 import com.ibanity.apis.client.products.xs2a.models.links.AccountInformationAccessLinks;
 import com.ibanity.apis.client.products.xs2a.models.links.AccountLinks;
+import com.ibanity.apis.client.products.xs2a.models.read.AccountInformationAccessRequestReadQuery;
 import com.ibanity.apis.client.products.xs2a.services.AccountInformationAccessRequestsService;
 import com.ibanity.apis.client.services.ApiUrlProvider;
 import lombok.*;
@@ -51,14 +52,25 @@ public class AccountInformationAccessRequestsServiceImpl implements AccountInfor
         return IbanityModelMapper.mapResource(response, responseMapping());
     }
 
+    @Deprecated
     @Override
     public com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest find(AccountInformationAccessRequestCreationQuery accountInformationAccessRequestCreationQuery) {
-        String financialInstitutionId = accountInformationAccessRequestCreationQuery.getFinancialInstitutionId().toString();
-        String resourceId = accountInformationAccessRequestCreationQuery.getAccountInformationAccessRequestId().toString();
+        return find(AccountInformationAccessRequestReadQuery.builder()
+                .accountInformationAccessRequestId(accountInformationAccessRequestCreationQuery.getAccountInformationAccessRequestId())
+                .financialInstitutionId(accountInformationAccessRequestCreationQuery.getFinancialInstitutionId())
+                .customerAccessToken(accountInformationAccessRequestCreationQuery.getCustomerAccessToken())
+                .additionalHeaders(accountInformationAccessRequestCreationQuery.getAdditionalHeaders())
+                .build());
+    }
+
+    @Override
+    public com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest find(AccountInformationAccessRequestReadQuery accountInformationAccessRequestReadQuery) {
+        String financialInstitutionId = accountInformationAccessRequestReadQuery.getFinancialInstitutionId().toString();
+        String resourceId = accountInformationAccessRequestReadQuery.getAccountInformationAccessRequestId().toString();
 
         URI uri = getUri(financialInstitutionId, resourceId);
 
-        String response = ibanityHttpClient.get(uri, accountInformationAccessRequestCreationQuery.getAdditionalHeaders(), accountInformationAccessRequestCreationQuery.getCustomerAccessToken());
+        String response = ibanityHttpClient.get(uri, accountInformationAccessRequestReadQuery.getAdditionalHeaders(), accountInformationAccessRequestReadQuery.getCustomerAccessToken());
         return IbanityModelMapper.mapResource(response, responseMapping());
     }
 

--- a/src/main/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImpl.java
+++ b/src/main/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImpl.java
@@ -4,8 +4,8 @@ import com.ibanity.apis.client.http.IbanityHttpClient;
 import com.ibanity.apis.client.jsonapi.DataApiModel;
 import com.ibanity.apis.client.jsonapi.RequestApiModel;
 import com.ibanity.apis.client.mappers.IbanityModelMapper;
+import com.ibanity.apis.client.models.IbanityModel;
 import com.ibanity.apis.client.models.IbanityProduct;
-import com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest;
 import com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequestMeta;
 import com.ibanity.apis.client.products.xs2a.models.AuthorizationPortal;
 import com.ibanity.apis.client.products.xs2a.models.FinancialInstitution;
@@ -15,9 +15,12 @@ import com.ibanity.apis.client.products.xs2a.models.links.AccountInformationAcce
 import com.ibanity.apis.client.products.xs2a.models.links.AccountLinks;
 import com.ibanity.apis.client.products.xs2a.services.AccountInformationAccessRequestsService;
 import com.ibanity.apis.client.services.ApiUrlProvider;
+import lombok.*;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 
 import static com.ibanity.apis.client.mappers.IbanityModelMapper.buildRequest;
@@ -35,7 +38,7 @@ public class AccountInformationAccessRequestsServiceImpl implements AccountInfor
     }
 
     @Override
-    public AccountInformationAccessRequest create(AccountInformationAccessRequestCreationQuery accountInformationAccessRequestCreationQuery) {
+    public com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest create(AccountInformationAccessRequestCreationQuery accountInformationAccessRequestCreationQuery) {
 
         String financialInstitutionId = accountInformationAccessRequestCreationQuery.getFinancialInstitutionId().toString();
 
@@ -49,7 +52,7 @@ public class AccountInformationAccessRequestsServiceImpl implements AccountInfor
     }
 
     @Override
-    public AccountInformationAccessRequest find(AccountInformationAccessRequestCreationQuery accountInformationAccessRequestCreationQuery) {
+    public com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest find(AccountInformationAccessRequestCreationQuery accountInformationAccessRequestCreationQuery) {
         String financialInstitutionId = accountInformationAccessRequestCreationQuery.getFinancialInstitutionId().toString();
         String resourceId = accountInformationAccessRequestCreationQuery.getAccountInformationAccessRequestId().toString();
 
@@ -64,13 +67,13 @@ public class AccountInformationAccessRequestsServiceImpl implements AccountInfor
         return buildUri(removeEnd(
                 url
                         .replace(FinancialInstitution.API_URL_TAG_ID, financialInstitutionId)
-                        .replace(AccountInformationAccessRequest.API_URL_TAG_ID, accountInformationAccessRequestId),
+                        .replace(com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest.API_URL_TAG_ID, accountInformationAccessRequestId),
                 "/"));
     }
 
-    private Function<DataApiModel, AccountInformationAccessRequest> responseMapping() {
+    private Function<DataApiModel, com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest> responseMapping() {
         return dataApiModel -> {
-            AccountInformationAccessRequest aiar = IbanityModelMapper.toIbanityModel(dataApiModel, AccountInformationAccessRequest.class);
+            com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest aiar = IbanityModelMapper.toIbanityModel(dataApiModel, com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest.class);
 
             aiar.setAccountInformationAccessLinks(AccountInformationAccessLinks.builder()
                     .redirect(dataApiModel.getLinks() == null ? null : dataApiModel.getLinks().getRedirect())
@@ -98,6 +101,7 @@ public class AccountInformationAccessRequestsServiceImpl implements AccountInfor
                 .customerIpAddress(creationQuery.getCustomerIpAddress())
                 .allowFinancialInstitutionRedirectUri(creationQuery.isAllowFinancialInstitutionRedirectUri())
                 .allowedAccountSubtypes(allowedAccountSubtypes.isEmpty() ? null : allowedAccountSubtypes)
+                .skipIbanityCompletionCallback(creationQuery.isSkipIbanityCompletionCallback())
                 .build();
     }
 
@@ -115,5 +119,32 @@ public class AccountInformationAccessRequestsServiceImpl implements AccountInfor
                             .build())
                     .build();
         }
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    private static class AccountInformationAccessRequest implements IbanityModel {
+
+        public static final String RESOURCE_TYPE = "accountInformationAccessRequest";
+        public static final String API_URL_TAG_ID = "{" + RESOURCE_TYPE + URL_PARAMETER_ID_POSTFIX + "}";
+
+        private UUID id;
+        private String selfLink;
+
+        private String consentReference;
+        private String redirectUri;
+        private String status;
+        private String locale;
+        private String customerIpAddress;
+        private boolean allowFinancialInstitutionRedirectUri;
+        private boolean skipIbanityCompletionCallback;
+
+        @Builder.Default
+        private List<String> requestedAccountReferences = Collections.emptyList();
+
+        @Builder.Default
+        private List<String> allowedAccountSubtypes = Collections.emptyList();
     }
 }

--- a/src/test/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImplTest.java
+++ b/src/test/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImplTest.java
@@ -8,6 +8,7 @@ import com.ibanity.apis.client.products.xs2a.models.create.AuthorizationPortalCr
 import com.ibanity.apis.client.products.xs2a.models.create.MetaRequestCreationQuery;
 import com.ibanity.apis.client.products.xs2a.models.links.AccountInformationAccessLinks;
 import com.ibanity.apis.client.products.xs2a.models.links.AccountLinks;
+import com.ibanity.apis.client.products.xs2a.models.read.AccountInformationAccessRequestReadQuery;
 import com.ibanity.apis.client.services.ApiUrlProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,8 +88,8 @@ class AccountInformationAccessRequestsServiceImplTest {
 
     @Test
     void find() throws Exception {
-        AccountInformationAccessRequestCreationQuery creationQuery =
-                AccountInformationAccessRequestCreationQuery.builder()
+        AccountInformationAccessRequestReadQuery creationQuery =
+                AccountInformationAccessRequestReadQuery.builder()
                         .customerAccessToken(CUSTOMER_ACCESS_TOKEN)
                         .financialInstitutionId(FINANCIAL_INSTITUTION_ID)
                         .accountInformationAccessRequestId(ACCOUNT_INFORMATION_ACCESS_REQUEST_ID)

--- a/src/test/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImplTest.java
+++ b/src/test/java/com/ibanity/apis/client/products/xs2a/services/impl/AccountInformationAccessRequestsServiceImplTest.java
@@ -1,11 +1,8 @@
 package com.ibanity.apis.client.products.xs2a.services.impl;
 
 import com.ibanity.apis.client.http.IbanityHttpClient;
-import com.ibanity.apis.client.jsonapi.RequestApiModel;
 import com.ibanity.apis.client.models.IbanityProduct;
 import com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequest;
-import com.ibanity.apis.client.products.xs2a.models.AccountInformationAccessRequestMeta;
-import com.ibanity.apis.client.products.xs2a.models.AuthorizationPortal;
 import com.ibanity.apis.client.products.xs2a.models.create.AccountInformationAccessRequestCreationQuery;
 import com.ibanity.apis.client.products.xs2a.models.create.AuthorizationPortalCreationQuery;
 import com.ibanity.apis.client.products.xs2a.models.create.MetaRequestCreationQuery;
@@ -28,6 +25,8 @@ import static com.ibanity.apis.client.utils.URIHelper.buildUri;
 import static java.util.Collections.emptyMap;
 import static java.util.UUID.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -78,7 +77,7 @@ class AccountInformationAccessRequestsServiceImplTest {
                                 .build())
                         .build();
 
-        when(ibanityHttpClient.post(buildUri(AIAR_ENDPOINT_FOR_CREATE), toIbanityModel(creationQuery), emptyMap(), creationQuery.getCustomerAccessToken()))
+        when(ibanityHttpClient.post(eq(buildUri(AIAR_ENDPOINT_FOR_CREATE)), any(), eq(emptyMap()), eq(creationQuery.getCustomerAccessToken())))
                 .thenReturn(loadFile("json/createAccountInformationAccessRequest.json"));
 
         AccountInformationAccessRequest actual = accountInformationAccessRequestsService.create(creationQuery);
@@ -101,30 +100,6 @@ class AccountInformationAccessRequestsServiceImplTest {
         AccountInformationAccessRequest actual = accountInformationAccessRequestsService.find(creationQuery);
 
         assertThat(actual).isEqualToComparingFieldByField(expectedForFind());
-    }
-
-    private RequestApiModel toIbanityModel(AccountInformationAccessRequestCreationQuery creationQuery) {
-        AccountInformationAccessRequest accessRequest = AccountInformationAccessRequest.builder()
-                .redirectUri(creationQuery.getRedirectUri())
-                .consentReference(creationQuery.getConsentReference())
-                .requestedAccountReferences(creationQuery.getRequestedAccountReferences())
-                .locale(creationQuery.getLocale())
-                .customerIpAddress(creationQuery.getCustomerIpAddress())
-                .allowedAccountSubtypes(creationQuery.getAllowedAccountSubtypes())
-                .build();
-        return RequestApiModel.builder()
-                .data(
-                        RequestApiModel.RequestDataApiModel.builder()
-                                .meta(AccountInformationAccessRequestMeta.builder()
-                                        .authorizationPortal(AuthorizationPortal.builder()
-                                                .disclaimerContent("disclaimerContent")
-                                                .build())
-                                        .build())
-                                .attributes(accessRequest)
-                                .type(AccountInformationAccessRequest.RESOURCE_TYPE)
-                                .build()
-                )
-                .build();
     }
 
     private AccountInformationAccessRequest expectedForFind() {

--- a/src/test/java/com/ibanity/samples/customer/AccountInformationAccessRequestSample.java
+++ b/src/test/java/com/ibanity/samples/customer/AccountInformationAccessRequestSample.java
@@ -6,6 +6,7 @@ import com.ibanity.apis.client.products.xs2a.models.FinancialInstitution;
 import com.ibanity.apis.client.products.xs2a.models.create.AccountInformationAccessRequestCreationQuery;
 import com.ibanity.apis.client.products.xs2a.models.create.AuthorizationPortalCreationQuery;
 import com.ibanity.apis.client.products.xs2a.models.create.MetaRequestCreationQuery;
+import com.ibanity.apis.client.products.xs2a.models.read.AccountInformationAccessRequestReadQuery;
 import com.ibanity.apis.client.products.xs2a.services.AccountInformationAccessRequestsService;
 import com.ibanity.apis.client.services.IbanityService;
 
@@ -28,7 +29,9 @@ public class AccountInformationAccessRequestSample {
                         .redirectUri(redirectUrl)
                         .consentReference(consentReference)
                         .allowFinancialInstitutionRedirectUri(true)
+                        .customerIpAddress("1.1.1.1")
                         .allowedAccountSubtypes(newArrayList("checking", "savings"))
+                        .skipIbanityCompletionCallback(false)
                         .metaRequestCreationQuery(MetaRequestCreationQuery.builder()
                                 .authorizationPortalCreationQuery(AuthorizationPortalCreationQuery.builder()
                                         .disclaimerContent("thisIsACusomOneContent")
@@ -43,7 +46,7 @@ public class AccountInformationAccessRequestSample {
     }
 
     public AccountInformationAccessRequest find(AccountInformationAccessRequest accountInformationAccessRequest, FinancialInstitution financialInstitution, CustomerAccessToken customerAccessToken) {
-        return accountInformationAccessRequestsService.find(AccountInformationAccessRequestCreationQuery.builder()
+        return accountInformationAccessRequestsService.find(AccountInformationAccessRequestReadQuery.builder()
                 .accountInformationAccessRequestId(accountInformationAccessRequest.getId())
                 .financialInstitutionId(financialInstitution.getId())
                 .customerAccessToken(customerAccessToken.getToken())


### PR DESCRIPTION
Add skipIbanityCompletionCallback to customize completion redirection flow.
Add AccountInformationAccessRequestService.find(AccountInformationAccessRequestReadQuery) and flag as AccountInformationAccessRequestService.find(AccountInformationAccessRequestCreationQuery) deprected.